### PR TITLE
Draft: feat: externalize isDev function && warn if no messages locale matche…

### DIFF
--- a/src/create-i18n.ts
+++ b/src/create-i18n.ts
@@ -1,7 +1,7 @@
 import {ref} from 'vue';
 import makeTranslator from './make-translator.js';
 import makePlugin from './make-plugin.js';
-import {log, err} from './utils.js';
+import {log, err, msg, isDev} from './utils.js';
 import {prepareAllMessages} from './prepare-messages.js';
 import type {PluginWithI18n, Settings} from './types.js';
 
@@ -16,14 +16,22 @@ export default function createI18n (settings: Settings): PluginWithI18n {
 
     settings.production = !!settings.production;
 
-    if (!settings.production && process.env.NODE_ENV !== 'production') {
+    if (!settings.production && isDev) {
         log('running in development mode (might be slower due to parsing linked messages at runtime)');
     }
 
+    const defaultLocale = 'en-US';
     const {messages: messagesRaw} = settings;
-    const locale = ref(settings.locale ?? 'en-US');
+    const locale = ref(settings.locale ?? defaultLocale);
     const fallbackLocale = ref(settings.fallbackLocale);
     const messages = settings.production ? messagesRaw : prepareAllMessages(messagesRaw);
+
+    if (isDev && !settings.locale && !Object.keys(messages).includes(defaultLocale)) {
+        console.warn(msg(
+            `No locale matching the default 'en-US' was found in your messages object. 
+            Either rename the default locale in your messages or specify a matching locale in your vue-i18n-pico config.`
+        ));
+    }
 
     const t = makeTranslator(messages, {locale, fallbackLocale});
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
 export const msg = (...args: unknown[]) => ['vue-i18n-pico:', ...args].join(' ');
 export const log = (...args: unknown[]) => console.log(msg(...args));
 export const err = (...args: unknown[]) => new Error(msg(...args));
+export const isDev = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
- externalized process.env.NODE_ENV check to util function isDev
- added console warning in dev mode when no locale was specified and no locale in given messages object matches the default locale of 'en-US'